### PR TITLE
fix google play image link

### DIFF
--- a/content/en/mobile_application/README.md
+++ b/content/en/mobile_application/README.md
@@ -5,7 +5,9 @@ Mobile Application
 
 Please click [here](https://play.google.com/store/apps/details?id=com.mediatek.iotcloud) or scan the QR code below to download the APK:
 
-<a href="https://play.google.com/store/apps/details?id=com.mediatek.iotcloud"><img src="https://developer.android.com/images/brand/en_app_rgb_wo_60.png" border="0"></a>
+<a href="https://play.google.com/store/apps/details?id=com.mediatek.iotcloud">
+  <img src="https://goo.gl/cIzlpF" border="0">
+</a>
 
 **(Please be noted that due to system upgrade to enhace security, the old version of mobile app is not working anymore. Please download the latest version of the mobile app in the Google play store to continue using our MCS mobile app.)**
 

--- a/content/zh-CN/mobile_application/README.md
+++ b/content/zh-CN/mobile_application/README.md
@@ -3,7 +3,9 @@
 
 您可以使用以下连结 [here](https://play.google.com/store/apps/details?id=com.mediatek.iotcloud) 或是QR码来下载我们提供的手机应用程序：
 
-<a href="https://play.google.com/store/apps/details?id=com.mediatek.iotcloud"><img src="https://developer.android.com/images/brand/en_app_rgb_wo_60.png" border="0"></a>
+<a href="https://play.google.com/store/apps/details?id=com.mediatek.iotcloud">
+  <img src="https://goo.gl/cIzlpF" border="0">
+</a>
 
 **(请注意：为了增加效能和安全性，我们将系统全面升级。旧版本的手机应用程式将不再能使用，请于Google play 商店下载最新版本的手机应用程式来连结您的手机与MCS平台)**
 

--- a/content/zh-TW/mobile_application/README.md
+++ b/content/zh-TW/mobile_application/README.md
@@ -3,7 +3,9 @@
 
 您可以使用以下連結 [here](https://play.google.com/store/apps/details?id=com.mediatek.iotcloud) 或是QR code來下載我們提供的手機應用程式:
 
-<a href="https://play.google.com/store/apps/details?id=com.mediatek.iotcloud"><img src="https://developer.android.com/images/brand/en_app_rgb_wo_60.png" border="0"></a>
+<a href="https://play.google.com/store/apps/details?id=com.mediatek.iotcloud">
+  <img src="https://goo.gl/cIzlpF" border="0">
+</a>
 
 **(請注意：為了增加效能和安全性，我們將系統全面升級。舊版本的手機應用程式將不再能使用，請於Google play 商店下載最新版本的手機應用程式來連結您的手機與MCS平台)**
 


### PR DESCRIPTION
因為 images 字串在 compile to html 的時候會被轉換成其他字，所以改用縮網址避開。
未來應修掉不要直接取代 images 字串，可加入前綴或後綴。
