### PR TITLE
Mcs 2667 update notification tutorial

### DIFF
--- a/content/en/tutorial/setting_notification.md
+++ b/content/en/tutorial/setting_notification.md
@@ -63,7 +63,6 @@ MCS provides pre-defined variables which can be used in both Title and Content f
 
 * **${deviceId}**: The ID of device
 * **${deviceName}**: The name of device
-* **${deviceKey}**: The key of device
 * **${value}**: The value of this data channel
 
 ![](../images/Trigger/img_trigger_09.png)

--- a/content/zh-CN/tutorial/setting_notification.md
+++ b/content/zh-CN/tutorial/setting_notification.md
@@ -62,7 +62,6 @@ MCS 预先定义了多个变数让您可以在通知的名称与内容栏位中�
 
 * **${deviceId}**: 设备的 ID
 * **${deviceName}**: 设备的名称
-* **${deviceKey}**: 设备的 Key
 * **${value}**: 资料通道的数值
 
 ![](../images/Trigger/img_trigger_09.png)

--- a/content/zh-TW/tutorial/setting_notification.md
+++ b/content/zh-TW/tutorial/setting_notification.md
@@ -62,7 +62,6 @@ MCS 預先定義了多個變數讓您可以在通知的名稱與內容欄位中�
 
 * **${deviceId}**: 設備的 ID
 * **${deviceName}**: 設備的名稱
-* **${deviceKey}**: 設備的 Key
 * **${value}**: 資料通道的數值
 
 ![](../images/Trigger/img_trigger_09.png)


### PR DESCRIPTION
Hi @anchi1216  and @appleboy, 
因應 MCS-2665 因為安全性因素，不可讓使用者在 Notification 裡面使用 ${deviceKey} 當變數，故移除 Tutorial 當中的有關 ${deviceKey} 的敘述。
