### PR TITLE
Typo: 移除範例程式碼上方的空白

### DIFF
--- a/content/en/tutorial/7688_videostream_tutorial.md
+++ b/content/en/tutorial/7688_videostream_tutorial.md
@@ -99,7 +99,6 @@ npm install mcsjs
 ```
 
 5. Test if FFmpeg can send streaming content to MCS successfully.
-
 ```
 ffmpeg -s 176x144 -f video4linux2 -r 30 -i /dev/video0 -f mpeg1video -r 30 -b 800k http://stream-mcs.mediatek.com/:deviceId/:deviceKey/:dataChnId/176/144
 ```


### PR DESCRIPTION
Hi @anchi1216 and @appleboy , 

修改 EN 版本，移除範例程式碼上方的空白
