### PR TITLE
MCS-3559: fix the incorrect hyperlink in 7697 tutorial.

### DIFF
--- a/content/en/tutorial/7697_tutorial.md
+++ b/content/en/tutorial/7697_tutorial.md
@@ -26,8 +26,8 @@ However, only TCP and HTTP protocols are supported in this library. Please refer
 ## Build your own Applications
 Choose the application you would like to start with:
 
-|[Control LED](./7697_led_control.md)|
+|[Control LED](./7697_led_control)|
 |---|
-|[![](../images/Linkit_ONE/img_linkitone_26.png)](./7697_led_control.md)|
+|[![](../images/Linkit_ONE/img_linkitone_26.png)](./7697_led_control)|
 
 

--- a/content/zh-CN/tutorial/7697_tutorial.md
+++ b/content/zh-CN/tutorial/7697_tutorial.md
@@ -27,8 +27,8 @@ LinkIt 7697 HDK 可支援 **Arduino IDE** 或是 **LinkIt SDK for RTOS** 两种�
 
 观看应用范例：
 
-|[控制 LED 灯号](./7697_led_control.md)|
+|[控制 LED 灯号](./7697_led_control)|
 |---|
-|[![](../images/Linkit_ONE/img_linkitone_26.png)](./7697_led_control.md)|
+|[![](../images/Linkit_ONE/img_linkitone_26.png)](./7697_led_control)|
 
 

--- a/content/zh-TW/tutorial/7697_tutorial.md
+++ b/content/zh-TW/tutorial/7697_tutorial.md
@@ -26,8 +26,8 @@ LinkIt 7697 HDK 可支援 **Arduino IDE** 或是 **LinkIt SDK for RTOS** 兩種�
 ## 打造您的應用程式
 觀看應用範例：
 
-|[控制 LED 燈號](./7697_led_control.md)|
+|[控制 LED 燈號](./7697_led_control)|
 |---|
-|[![](../images/Linkit_ONE/img_linkitone_26.png)](./7697_led_control.md)|
+|[![](../images/Linkit_ONE/img_linkitone_26.png)](./7697_led_control)|
 
 


### PR DESCRIPTION
fix the hyperlink in 7697 tutorial.